### PR TITLE
timetableを上に持ってくる

### DIFF
--- a/source/index.html.slim
+++ b/source/index.html.slim
@@ -5,9 +5,9 @@ header
   ul
     li.yellow-border.sm = link_to "EVENT", "#event"
     li ｜
-    li.yellow-border.sm = link_to "DJ", "#dj"
-    li ｜
     li.yellow-border.sm = link_to "TIME TABLE", "#time_table"
+    li ｜
+    li.yellow-border.sm = link_to "MEMBER", "#member"
     li ｜
     li.yellow-border.sm = link_to "ACCESS", "#access"
 
@@ -26,9 +26,9 @@ header
   a.sq-btn.sq-btn-blue.text-center(href="#access")
     | ACCESS
 
-a(name="dj")
+a(name="member")
 .black-container
-  h2.ex-header.text-center DJ
+  h2.ex-header.text-center MEMBER
   .members
     - data.members.each do |member|
       .member

--- a/source/index.html.slim
+++ b/source/index.html.slim
@@ -26,22 +26,6 @@ header
   a.sq-btn.sq-btn-blue.text-center(href="#access")
     | ACCESS
 
-a(name="member")
-.black-container
-  h2.ex-header.text-center MEMBER
-  .members
-    - data.members.each do |member|
-      .member
-        .border
-          .left
-            .icon
-              = image_tag(member.icon, width: "80px")
-          .right
-            strong
-              span.name = member.name
-              = link_to image_tag("new_window.png"), member.services&.first.url, class: "new-window"
-            .profile = member.description
-
 a(name="time_table")
 .container.time-table
   h2.ex-header.text-center.time-table TIME TABLE
@@ -64,6 +48,22 @@ a(name="time_table")
       span
         | ,&nbsp;
       span: strong Takayuki Tominaga
+
+a(name="member")
+.black-container
+  h2.ex-header.text-center MEMBER
+  .members
+    - data.members.each do |member|
+      .member
+        .border
+          .left
+            .icon
+              = image_tag(member.icon, width: "80px")
+          .right
+            strong
+              span.name = member.name
+              = link_to image_tag("new_window.png"), member.services&.first.url, class: "new-window"
+            .profile = member.description
 
 a(name="access")
 .black-container.venues

--- a/source/stylesheets/_definition.scss
+++ b/source/stylesheets/_definition.scss
@@ -30,6 +30,7 @@ h2.ex-header {
   font-size: 4rem;
   font-family: 'Montserrat', sans-serif;
   font-weight: bold;
+  margin-top: 0px;
 }
 
 h2.ex-header.event {


### PR DESCRIPTION
某所での会話より、timetableが上にあったほうが誤解が少ないので移動させました。

![Screenshot from 2019-06-10 23-24-22](https://user-images.githubusercontent.com/4487291/59202441-6fb6ef00-8bd7-11e9-925c-84c7c1ed967c.png)

| before | after |
| --- | --- |
| ![2019-06-10 23 23 38 kosendj-bu in 49af51fb9721](https://user-images.githubusercontent.com/4487291/59202475-83625580-8bd7-11e9-8287-e4d2680de59a.jpg) | ![2019-06-10 21 53 04 localhost fcc9ebf4fc97](https://user-images.githubusercontent.com/4487291/59202474-83625580-8bd7-11e9-8415-886ab1a7f262.jpg) |

